### PR TITLE
add matching pattern

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -207,7 +207,6 @@ class AbstractChosen
   search_string_match: (search_string, regex, option_html) ->
     if option_html.indexOf(search_string) > 0
       return true
-      
     if regex.test search_string
       return true
     else if @enable_split_word_search and (search_string.indexOf(" ") >= 0 or search_string.indexOf("[") == 0)


### PR DESCRIPTION
English:Increase the matching option, from any string to start matching, is no longer limited to the beginning of the matching and the matching from the space
中文：增加匹配option的时候，从任意字符串开始匹配，不再局限于从头匹配和从空格处开始匹配
